### PR TITLE
fix: verify the changelog before it is commited

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ npm run changelog
 ```
 
 For best results, try to run this after every time you publish.
+
+## Command line options
+
+### `--force`
+
+By default, this script verifies that the changelog diff contains no more than
+5 deletions. With `--force` enabled, this step is skipped.

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ function run() {
 
   var changelog_was_updated = false;
   exec('git ls-files --exclude-standard --modified --others').split('\n').forEach(function (file) {
-    if ( file === 'CHANGELOG.md') changelog_was_updated = true;
+    if (file === 'CHANGELOG.md') changelog_was_updated = true;
   });
 
   if (changelog_was_updated) {

--- a/index.js
+++ b/index.js
@@ -11,12 +11,12 @@ function parseGitUri(uri) {
 }
 
 function verifyChangelog() {
-  var changelog = exec('git diff HEAD~1');
-  var lines = changelog.split('\n');
-  var isOneLine = (lines.length === 1);
+  var diff = exec('git diff HEAD~1').split('\n');
+  var changelog = cat('CHANGELOG.md').split('\n');
+  var isOneLine = (changelog.length === 1);
   var deletions = 0;
   var containsErrorMessage = false;
-  lines.filter(function (line) {
+  diff.filter(function (line) {
     if (/^-/.test(line)) deletions++;
     if (line.indexOf('Make a POST first') >= 0) containsErrorMessage = true;
   });

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ require('shelljs/global');
 // The maximum number of deletions for updating the changelog should
 // be 2 lines. Typically, the "Unreleased" and "Full Changelog" links
 // are changed because the version increases.
-var maxDeletions = 2;
+var MAX_DELETIONS = 2;
 
 function parseGitUri(uri) {
   return uri.match(/https:..github.com\/([^./]+)\/([^./]+).*/) ||
@@ -31,7 +31,7 @@ function verifyChangelog() {
     'Changelog diff should be more than 1 line long'
   );
   assert(
-    deletions < maxDeletions,
+    deletions < MAX_DELETIONS,
     'Too many deletions (-' + deletions + '), verify that the changes to CHANGELOG.md are correct'
   );
   assert(

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function parseGitUri(uri) {
 function verifyChangelog() {
   var diff = exec('git diff HEAD CHANGELOG.md').split('\n');
   var changelog = cat('CHANGELOG.md').split('\n');
+  if (changelog[changelog.length - 1] === '') changelog.pop();
   var isOneLine = (changelog.length === 1);
   var deletions = 0;
   var containsErrorMessage = false;

--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ function verifyChangelog() {
   if (changelog[changelog.length - 1] === '') changelog.pop();
   var isOneLine = (changelog.length === 1);
   var deletions = diff.filter(/^-/.test).length;
-  var containsErrorMessage = false;
+  var containsError = false;
   diff.forEach(function (line) {
-    if (line.indexOf('Make a POST first') >= 0) containsErrorMessage = true;
+    if (line.indexOf('Make a POST first') >= 0) containsError = true;
   });
   if (isOneLine) {
     revertChanges();
@@ -30,7 +30,7 @@ function verifyChangelog() {
     console.error('Too many deletions (-' + deletions + '), verify that the changes to CHANGELOG.md are correct');
     process.exit(4);
   }
-  if (containsErrorMessage) {
+  if (containsError) {
     revertChanges();
     console.error('Changelog contains an error message');
     process.exit(5);

--- a/index.js
+++ b/index.js
@@ -15,10 +15,9 @@ function verifyChangelog() {
   var changelog = cat('CHANGELOG.md').split('\n');
   if (changelog[changelog.length - 1] === '') changelog.pop();
   var isOneLine = (changelog.length === 1);
-  var deletions = 0;
+  var deletions = diff.filter(/^-/.test).length;
   var containsErrorMessage = false;
-  diff.filter(function (line) {
-    if (/^-/.test(line)) deletions++;
+  diff.forEach(function (line) {
     if (line.indexOf('Make a POST first') >= 0) containsErrorMessage = true;
   });
   if (isOneLine) {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ require('shelljs/global');
 // Commits the changelog if it updated
 // Does not push commit
 
+// The maximum number of deletions for updating the changelog should
+// be 2 lines. Typically, the "Unreleased" and "Full Changelog" links
+// are changed because the version increases.
+var maxDeletions = 2;
+
 function parseGitUri(uri) {
   return uri.match(/https:..github.com\/([^./]+)\/([^./]+).*/) ||
     uri.match(/git@github.com:(.*)\/(.*)\.git/);
@@ -26,7 +31,7 @@ function verifyChangelog() {
     'Changelog diff should be more than 1 line long'
   );
   assert(
-    deletions < 10,
+    deletions < maxDeletions,
     'Too many deletions (-' + deletions + '), verify that the changes to CHANGELOG.md are correct'
   );
   assert(

--- a/index.js
+++ b/index.js
@@ -38,13 +38,11 @@ function verifyChangelog() {
     !containsError,
     'Changelog contains an error message.'
   );
-  if (!force) {
-    assert(
-      deletions < MAX_DELETIONS,
-      'Too many deletions (-' + deletions + '), this is probably an error.\n' +
-      'Run with --force to ignore this error.'
-    );
-  }
+  assert(
+    deletions < MAX_DELETIONS,
+    'Too many deletions (-' + deletions + '), this is probably an error.\n' +
+    'Run with --force to ignore this error.'
+  );
 }
 
 function revertChanges() {
@@ -81,13 +79,15 @@ function run() {
   });
 
   if (changelog_was_updated) {
-    try {
-      echo('...verifying changelog');
-      verifyChangelog();
-    } catch (err) {
-      revertChanges();
-      console.error(err.message);
-      process.exit(1);
+    if (!force) {
+      try {
+        echo('...verifying changelog');
+        verifyChangelog();
+      } catch (err) {
+        revertChanges();
+        console.error(err.message);
+        process.exit(1);
+      }
     }
     echo('...committing updated changelog');
     var current_user = exec('git config user.name').trimRight();

--- a/index.js
+++ b/index.js
@@ -28,15 +28,15 @@ function verifyChangelog() {
   });
   assert(
     changelog.length > 1,
-    'Changelog diff should be more than 1 line long'
+    'Changelog was reduced to one line, this is an error.'
   );
   assert(
     deletions < MAX_DELETIONS,
-    'Too many deletions (-' + deletions + '), verify that the changes to CHANGELOG.md are correct'
+    'Too many deletions (-' + deletions + '), this is probably an error.'
   );
   assert(
     !containsError,
-    'Changelog contains an error message'
+    'Changelog contains an error message.'
   );
 }
 

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ require('shelljs/global');
 // Does not push commit
 
 // The maximum number of deletions for updating the changelog should
-// be 2 lines. Typically, the "Unreleased" and "Full Changelog" links
+// be 5 lines. Typically, the "Unreleased" and "Full Changelog" links
 // are changed because the version increases.
-var MAX_DELETIONS = 2;
+var MAX_DELETIONS = 5;
 
 function parseGitUri(uri) {
   return uri.match(/https:..github.com\/([^./]+)\/([^./]+).*/) ||

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function parseGitUri(uri) {
 }
 
 function verifyChangelog() {
-  var diff = exec('git diff HEAD~1').split('\n');
+  var diff = exec('git diff HEAD CHANGELOG.md').split('\n');
   var changelog = cat('CHANGELOG.md').split('\n');
   var isOneLine = (changelog.length === 1);
   var deletions = 0;


### PR DESCRIPTION
Fixes #3 

Verify the following about the changelog before it is commited:

* It is not one line long.
* It does not contain more than 10 deletions.
* It does not contain the error message "There is no job for ...
  Make a POST first."